### PR TITLE
Bugfix: calculating the CPU percentage is wrong

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.inferGopath": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.inferGopath": false
+}

--- a/util.go
+++ b/util.go
@@ -101,8 +101,7 @@ func getUsageNormal() (float64, float64, int, int, error) {
 		return 0, 0, 0, 0, err
 	}
 
-	// The default percent is from all cores, use runtime.NumCPU()
-	// if you use one core, then 100%, two core, 200%
+	// The default percent is from all cores, multiply by runtime.NumCPU()
 	// but it's inconvenient to calculate the proper percent
 	// here we divide by core number, so we can set a percent bar more intuitively
 	cpuPercent = cpuPercent / float64(runtime.NumCPU())

--- a/util.go
+++ b/util.go
@@ -102,6 +102,7 @@ func getUsageNormal() (float64, float64, int, int, error) {
 	}
 
 	// The default percent is from all cores, use runtime.NumCPU()
+	// if you use one core, then 100%, two core, 200%
 	// but it's inconvenient to calculate the proper percent
 	// here we divide by core number, so we can set a percent bar more intuitively
 	cpuPercent = cpuPercent / float64(runtime.NumCPU())

--- a/util.go
+++ b/util.go
@@ -65,8 +65,8 @@ func getUsageCGroup() (float64, float64, int, int, error) {
 	}
 
 	// the same with physical machine
-	// need to divide by core
-	cpuPercent = cpuPercent / float64(runtime.GOMAXPROCS(-1))
+	// need to divide by core number
+	cpuPercent = cpuPercent / float64(runtime.NumCPU())
 
 	mem, err := p.MemoryInfo()
 	if err != nil {
@@ -101,10 +101,10 @@ func getUsageNormal() (float64, float64, int, int, error) {
 		return 0, 0, 0, 0, err
 	}
 
-	// The default percent is if you use one core, then 100%, two core, 200%
+	// The default percent is from all cores, use runtime.NumCPU()
 	// but it's inconvenient to calculate the proper percent
-	// here we multiply by core number, so we can set a percent bar more intuitively
-	cpuPercent = cpuPercent / float64(runtime.GOMAXPROCS(-1))
+	// here we divide by core number, so we can set a percent bar more intuitively
+	cpuPercent = cpuPercent / float64(runtime.NumCPU())
 
 	mem, err := p.MemoryPercent()
 	if err != nil {


### PR DESCRIPTION
The default percent is from all cores, use runtime.NumCPU().
But it's inconvenient to calculate the proper percent.
Here we divide by core number, so we can set a percent bar more intuitively

```go
// https://github.com/shirou/gopsutil/blob/7ea8062810b6e3076ab6c4b40d6f24421e92a889/process/process.go#L238
numcpu := runtime.NumCPU()
...
overall_percent := ((delta_proc / delta) * 100) * float64(numcpu)
```