### PR TITLE
fix: bugFix cpu num in docker

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -55,7 +55,11 @@ var type2name = map[configureType]string{
 	goroutine: "goroutine",
 }
 
-const cgroupMemLimitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+const (
+	cgroupMemLimitPath  = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+	cgroupCpuQuotaPath  = "/sys/fs/cgroup/cpuacct/cpu.cfs_quota_us"
+	cgroupCpuPeriodPath = "/sys/fs/cgroup/cpuacct/cpu.cfs_period_us"
+)
 
 const minCollectCyclesBeforeDumpStart = 10
 

--- a/consts.go
+++ b/consts.go
@@ -57,8 +57,8 @@ var type2name = map[configureType]string{
 
 const (
 	cgroupMemLimitPath  = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-	cgroupCpuQuotaPath  = "/sys/fs/cgroup/cpuacct/cpu.cfs_quota_us"
-	cgroupCpuPeriodPath = "/sys/fs/cgroup/cpuacct/cpu.cfs_period_us"
+	cgroupCpuQuotaPath  = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+	cgroupCpuPeriodPath = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
 )
 
 const minCollectCyclesBeforeDumpStart = 10

--- a/example/run_in_docker/run_in_docker.go
+++ b/example/run_in_docker/run_in_docker.go
@@ -9,6 +9,8 @@ import (
 
 func init() {
 	http.HandleFunc("/docker", dockermake1gb)
+	http.HandleFunc("/docker/cpu", cpuex)
+	http.HandleFunc("/docker/cpu_multi_core", cpuMulticore)
 	go http.ListenAndServe(":10003", nil)
 }
 
@@ -18,11 +20,31 @@ func main() {
 		holmes.WithCoolDown("1m"),
 		holmes.WithDumpPath("/tmp"),
 		holmes.WithTextDump(),
+		holmes.WithLoggerLevel(holmes.LogLevelDebug),
 		holmes.WithMemDump(3, 25, 80),
+		holmes.WithCPUDump(60, 10, 80),
 		holmes.WithCGroup(true),
 	)
-	h.EnableMemDump().Start()
+	h.EnableCPUDump()
+	h.EnableMemDump()
+	h.Start()
 	time.Sleep(time.Hour)
+}
+
+func cpuex(wr http.ResponseWriter, req *http.Request) {
+	go func() {
+		for {
+		}
+	}()
+}
+
+func cpuMulticore(wr http.ResponseWriter, req *http.Request) {
+	for i := 1; i <= 100; i++ {
+		go func() {
+			for {
+			}
+		}()
+	}
 }
 
 func dockermake1gb(wr http.ResponseWriter, req *http.Request) {

--- a/util.go
+++ b/util.go
@@ -64,10 +64,20 @@ func getUsageCGroup() (float64, float64, int, int, error) {
 		return 0, 0, 0, 0, err
 	}
 
+	cpuPeriod, err := readUint(cgroupCpuPeriodPath)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+
+	cpuQuota, err := readUint(cgroupCpuQuotaPath)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	cpuCore := float64(cpuQuota) / float64(cpuPeriod)
+
 	// the same with physical machine
 	// need to divide by core number
-	cpuPercent = cpuPercent / float64(runtime.NumCPU())
-
+	cpuPercent = cpuPercent / cpuCore
 	mem, err := p.MemoryInfo()
 	if err != nil {
 		return 0, 0, 0, 0, err


### PR DESCRIPTION
In the container environment, the number of cpu cores is limited, runtime.NumCpu() gets the number of cpus of the host machine.
The CPU quota of the container determines the number of cores by the size ratio between period and quota.