### PR TITLE
fix:bugFix memoryLimit get

### DIFF
--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package holmes
 
 import (
 	"bytes"
-	"context"
 	"io/ioutil"
 	"math"
 	"os"
@@ -82,6 +81,7 @@ func getUsageCGroup() (float64, float64, int, int, error) {
 	// need to divide by core number
 	cpuPercent = cpuPercent / cpuCore
 	mem, err := p.MemoryInfo()
+	p.MemoryPercent()
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
@@ -105,7 +105,7 @@ func getCGroupMemoryLimit() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	machineMemory, err := mem_util.VirtualMemoryWithContext(context.TODO())
+	machineMemory, err := mem_util.VirtualMemory()
 	if err != nil {
 		return 0, err
 	}

--- a/util.go
+++ b/util.go
@@ -2,7 +2,9 @@ package holmes
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
+	"math"
 	"os"
 	"path"
 	"runtime"
@@ -11,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	mem_util "github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/process"
 )
 
@@ -83,11 +86,10 @@ func getUsageCGroup() (float64, float64, int, int, error) {
 		return 0, 0, 0, 0, err
 	}
 
-	memLimit, err := readUint(cgroupMemLimitPath)
+	memLimit, err := getCGroupMemoryLimit()
 	if err != nil {
 		return 0, 0, 0, 0, err
 	}
-
 	// mem.RSS / cgroup limit in bytes
 	memPercent := float64(mem.RSS) * 100 / float64(memLimit)
 
@@ -96,6 +98,19 @@ func getUsageCGroup() (float64, float64, int, int, error) {
 	tNum := getThreadNum()
 
 	return cpuPercent, memPercent, gNum, tNum, nil
+}
+
+func getCGroupMemoryLimit() (uint64, error) {
+	usage, err := readUint(cgroupMemLimitPath)
+	if err != nil {
+		return 0, err
+	}
+	machineMemory, err := mem_util.VirtualMemoryWithContext(context.TODO())
+	if err != nil {
+		return 0, err
+	}
+	limit := uint64(math.Min(float64(usage), float64(machineMemory.Total)))
+	return limit, nil
 }
 
 // return cpu percent, mem in MB, goroutine num


### PR DESCRIPTION
If the memory limit is not set in the container environment, memory.limit_in_bytes is a large value, which is not equal to the memory size of the host, so here you need to take the smaller value of the host and set limit