### PR TITLE
docs: break long sentences and fix some typos.

### DIFF
--- a/holmes.go
+++ b/holmes.go
@@ -178,6 +178,10 @@ func (h *Holmes) goroutineCheckAndDump(gNum int) {
 
 func (h *Holmes) goroutineProfile(gNum int) bool {
 	c := h.opts.GrOpts
+	if ReachDangerousLimit(gNum, c.GoroutineDangerousNumber) {
+		h.logf("[Holmes] current goroutines number [%v] greater than dangerous limit [%v], don't create profile", gNum, c.GoroutineDangerousNumber)
+		return false
+	}
 	if !matchRule(h.grNumStats, gNum, c.GoroutineTriggerNumMin, c.GoroutineTriggerNumAbs, c.GoroutineTriggerPercentDiff) {
 		h.debugUniform("NODUMP", type2name[goroutine],
 			c.GoroutineTriggerNumMin, c.GoroutineTriggerPercentDiff, c.GoroutineTriggerNumAbs,
@@ -212,6 +216,10 @@ func (h *Holmes) memCheckAndDump(mem int) {
 
 func (h *Holmes) memProfile(rss int) bool {
 	c := h.opts.MemOpts
+	if ReachDangerousLimit(rss, c.MemDangerousPercent) {
+		h.logf("[Holmes] current mem percent [%v] greater than dangerous limit [%v], don't create profile", rss, c.MemDangerousPercent)
+		return false
+	}
 	if !matchRule(h.memStats, rss, c.MemTriggerPercentMin, c.MemTriggerPercentAbs, c.MemTriggerPercentDiff) {
 		// let user know why this should not dump
 		h.debugUniform("NODUMP", type2name[mem],
@@ -285,6 +293,10 @@ func (h *Holmes) cpuCheckAndDump(cpu int) {
 
 func (h *Holmes) cpuProfile(curCPUUsage int) bool {
 	c := h.opts.CPUOpts
+	if ReachDangerousLimit(curCPUUsage, c.CPUDangerousPercent) {
+		h.logf("[Holmes] current cpu percent [%v] greater than dangerous limit [%v], don't create profile", curCPUUsage, c.CPUDangerousPercent)
+		return false
+	}
 	if !matchRule(h.cpuStats, curCPUUsage, c.CPUTriggerPercentMin, c.CPUTriggerPercentAbs, c.CPUTriggerPercentDiff) {
 		// let user know why this should not dump
 		h.debugUniform("NODUMP", type2name[cpu],

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package holmes
 
 import (
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -80,6 +81,39 @@ func WithCoolDown(coolDown string) Option {
 	})
 }
 
+// WithCPUDangerousPercent : set the CPU dangerousLimit parameter as d
+func WithCPUDangerousPercent(d int) Option {
+	return optionFunc(func(opts *options) (err error) {
+		if opts.CPUOpts == nil {
+			return errors.New("CPU option is nil, initial cpu option before setting dangerous limit")
+		}
+		opts.CPUOpts.CPUDangerousPercent = d
+		return
+	})
+}
+
+// WithMemDangerousPercent : set the Mem dangerousLimit parameter as d
+func WithMemDangerousPercent(d int) Option {
+	return optionFunc(func(opts *options) (err error) {
+		if opts.MemOpts == nil {
+			return errors.New("memory option is nil, initial cpu option before setting dangerous limit")
+		}
+		opts.MemOpts.MemDangerousPercent = d
+		return
+	})
+}
+
+// WithGoroutinesDangerousNumber : set the Goroutines dangerousLimit num as d
+func WithGoroutinesDangerousNumber(d int) Option {
+	return optionFunc(func(opts *options) (err error) {
+		if opts.GrOpts == nil {
+			return errors.New("goroutines num option is nil, initial cpu option before setting dangerous limit")
+		}
+		opts.GrOpts.GoroutineDangerousNumber = d
+		return
+	})
+}
+
 // WithDumpPath set the dump path for holmes.
 func WithDumpPath(dumpPath string, loginfo ...string) Option {
 	return optionFunc(func(opts *options) (err error) {
@@ -135,6 +169,10 @@ type grOptions struct {
 	GoroutineTriggerNumMin      int // goroutine trigger min in number
 	GoroutineTriggerPercentDiff int // goroutine trigger diff in percent
 	GoroutineTriggerNumAbs      int // goroutine trigger abs in number
+
+	// if current goroutine number is greater than GoroutineDangerousNumber,
+	// holmes would not dump profile, cuz this move may result of the system crash.
+	GoroutineDangerousNumber int
 }
 
 func newGrOptions() *grOptions {
@@ -164,6 +202,10 @@ type memOptions struct {
 	MemTriggerPercentMin  int // mem trigger minimum in percent
 	MemTriggerPercentDiff int // mem trigger diff in percent
 	MemTriggerPercentAbs  int // mem trigger absolute in percent
+
+	// if current Mem usage percent is greater than MemDangerousPercent,
+	// holmes would not dump profile, cuz this move may result of the system crash.
+	MemDangerousPercent int
 }
 
 func newMemOptions() *memOptions {
@@ -218,7 +260,11 @@ type cpuOptions struct {
 	Enable                bool
 	CPUTriggerPercentMin  int // cpu trigger min in percent
 	CPUTriggerPercentDiff int // cpu trigger diff in percent
-	CPUTriggerPercentAbs  int // cpu trigger abs inpercent
+	CPUTriggerPercentAbs  int // cpu trigger abs in percent
+
+	// if current cpu usage percent is greater than CPUDangerousPercent,
+	// holmes would not dump profile, cuz this move may result of the system crash.
+	CPUDangerousPercent int
 }
 
 func newCPUOptions() *cpuOptions {

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,7 @@ h, _ := holmes.New(
     holmes.WithDumpPath("/tmp"),
     holmes.WithTextDump(),
     holmes.WithGoroutineDump(10, 25, 2000),
+    holmes.WithGoroutinesDangerousNumber(100*10000)
 )
 h.EnableGoroutineDump()
 
@@ -38,7 +39,9 @@ h.Stop()
   will write content to /tmp dir
 * WithTextDump() means not in binary mode, so it's text mode profiles
 * WithGoroutineDump(10, 25, 2000) means dump will happen when current_goroutine_num > 10 && 
-  current_goroutine_num > 125% * previous_average_goroutine_num or current_goroutine_num > 2000
+  current_goroutine_num > 125% * previous_average_goroutine_num or current_goroutine_num > 2000.
+* WithGoroutinesDangerousNumber means holmes would not dump profile if current goroutine numbers
+  is greater than DangerousNumber.
 
 ### dump cpu profile when cpu load spikes
 
@@ -48,6 +51,7 @@ h, _ := holmes.New(
     holmes.WithCoolDown("1m"),
     holmes.WithDumpPath("/tmp"),
     holmes.WithCPUDump(20, 25, 80),
+    holmes.WithCPUDangerousPercent(90),
 )
 h.EnableCPUDump()
 
@@ -67,6 +71,8 @@ h.Stop()
   standard library doesn't support text mode dump.
 * WithCPUDump(10, 25, 80) means dump will happen when cpu usage > 10% && 
   cpu usage > 125% * previous cpu usage recorded or cpu usage > 80%.
+* WithCPUDangerousPercent means holmes would not dump profile if current cpu usage percent
+  is greater than DangerousNumber.  
 
 ### dump heap profile when RSS spikes
 
@@ -77,6 +83,7 @@ h, _ := holmes.New(
     holmes.WithDumpPath("/tmp"),
     holmes.WithTextDump(),
     holmes.WithMemDump(30, 25, 80),
+    holmes.WithMemDangerousPercent(90)
 )
 
 h.EnableMemDump()
@@ -96,7 +103,9 @@ h.Stop()
 * WithTextDump() means not in binary mode, so it's text mode profiles
 * WithMemDump(30, 25, 80) means dump will happen when memory usage > 10% && 
   memory usage > 125% * previous memory usage or memory usage > 80%.
-
+* WithMemDangerousPercent means holmes would not dump profile if current Mem usage percent
+  is greater than DangerousPercent.
+  
 ### enable them all!
 
 It's easy.

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,12 @@
 # holmes
 
-**WARNING** : holmes is under heavy development now, so API will make breaking change during dev. If you want to use it in production, please wait for the first release.
+**WARNING** : holmes is under heavy development now, so API will make breaking change during dev. 
+If you want to use it in production, please wait for the first release.
 
 Self-aware Golang profile dumper.
 
-Our online system often crashes at midnight (usually killed by the OS due to OOM). As lazy developers, we don't want to be woken up at midnight and waiting for the online error to recur.
+Our online system often crashes at midnight (usually killed by the OS due to OOM). 
+As lazy developers, we don't want to be woken up at midnight and waiting for the online error to recur.
 
 holmes comes to rescue.
 
@@ -30,10 +32,13 @@ h.Stop()
 ```
 
 * WithCollectInterval("5s") means the system metrics are collected once 5 seconds
-* WithCoolDown("1m") means once a dump happened, the next dump will not happen before cooldown finish-1 minute.
-* WithDumpPath("/tmp") means the dump binary file(binary mode) or the dump log file(text mode) will write content to /tmp dir
+* WithCoolDown("1m") means once a dump happened, the next dump will not happen before cooldown 
+  finish-1 minute.
+* WithDumpPath("/tmp") means the dump binary file(binary mode) or the dump log file(text mode) 
+  will write content to /tmp dir
 * WithTextDump() means not in binary mode, so it's text mode profiles
-* WithGoroutineDump(10, 25, 2000) means dump will happen when current_goroutine_num > 10 && current_goroutine_num > 125% * previous_average_goroutine_num or current_goroutine_num > 2000
+* WithGoroutineDump(10, 25, 2000) means dump will happen when current_goroutine_num > 10 && 
+  current_goroutine_num > 125% * previous_average_goroutine_num or current_goroutine_num > 2000
 
 ### dump cpu profile when cpu load spikes
 
@@ -54,10 +59,14 @@ h.Stop()
 ```
 
 * WithCollectInterval("5s") means the system metrics are collected once 5 seconds
-* WithCoolDown("1m") means once a dump happened, the next dump will not happen before cooldown finish-1 minute.
-* WithDumpPath("/tmp") means the dump binary file(binary mode) or the dump log file(text mode) will write content to /tmp dir
-* WithBinaryDump() or WithTextDump() doesn't affect the CPU profile dump, because the pprof standard library doesn't support text mode dump
-* WithCPUDump(10, 25, 80) means dump will happen when cpu usage > 10% && cpu usage > 125% * previous cpu usage recorded or cpu usage > 80%
+* WithCoolDown("1m") means once a dump happened, the next dump will not happen before 
+  cooldown finish-1 minute.
+* WithDumpPath("/tmp") means the dump binary file(binary mode), or the dump log file(text mode) 
+  will write content to `/tmp` dir.
+* WithBinaryDump() or WithTextDump() doesn't affect the CPU profile dump, because the pprof 
+  standard library doesn't support text mode dump.
+* WithCPUDump(10, 25, 80) means dump will happen when cpu usage > 10% && 
+  cpu usage > 125% * previous cpu usage recorded or cpu usage > 80%.
 
 ### dump heap profile when RSS spikes
 
@@ -80,10 +89,13 @@ h.Stop()
 ```
 
 * WithCollectInterval("5s") means the system metrics are collected once 5 seconds
-* WithCoolDown("1m") means once a dump happened, the next dump will not happen before cooldown finish-1 minute.
-* WithDumpPath("/tmp") means the dump binary file(binary mode) or the dump log file(text mode) will write content to /tmp dir
+* WithCoolDown("1m") means once a dump happened, the next dump will not happen before 
+  cooldown finish-1 minute.
+* WithDumpPath("/tmp") means the dump binary file(binary mode), or the dump log file(text mode) 
+  will write content to `/tmp` dir.
 * WithTextDump() means not in binary mode, so it's text mode profiles
-* WithMemDump(30, 25, 80) means dump will happen when memory usage > 10% && memory usage > 125% * previous memory usage or memory usage > 80%
+* WithMemDump(30, 25, 80) means dump will happen when memory usage > 10% && 
+  memory usage > 125% * previous memory usage or memory usage > 80%.
 
 ### enable them all!
 
@@ -133,11 +145,15 @@ Holmes collects the following stats every interval passed:
 * RSS used by the current process with [gopsutil](https://github.com/shirou/gopsutil)
 * CPU percent a total. eg total 8 core, use 4 core = 50% with [gopsutil](https://github.com/shirou/gopsutil) 
 
-After warming up phase finished, Holmes will compare the current stats with the average of previous collected stats(10 cycles). If the dump rule is matched, Holmes will dump the related profile to log(text mode) or binary file(binary mode).
+After warming up phase finished, Holmes will compare the current stats with the average 
+of previous collected stats(10 cycles). If the dump rule is matched, Holmes will dump 
+the related profile to log(text mode) or binary file(binary mode).
 
-When you get warning messages sent by your own monitor system, eg. memory usage exceed 80%, OOM killed, CPU usage exceed 80%, goroutine nun exceed 100k. The profile is already dumped to your dump path. You could just fetch the profile and see what actually happend without pressure.
+When you get warning messages sent by your own monitor system, e.g, memory usage exceed 80%, 
+OOM killed, CPU usage exceed 80%, goroutine num exceed 100k. The profile is already dumped 
+to your dump path. You could just fetch the profile and see what actually happened without pressure.
 
-## case show
+## cases show
 
 ### RSS peak caused by make a 1GB slice
 
@@ -165,7 +181,8 @@ curl localhost:10003/lockorder1
 
 curl localhost:10003/lockorder2
 
-After warming up, wrk -c 100 http://localhost:10003/req, then you'll see the deadlock caused goroutine num peak:
+After warming up, wrk -c 100 http://localhost:10003/req, then you'll see the deadlock 
+caused goroutine num peak:
 
 ```
 100 @ 0x40380b0 0x4048c80 0x4048c6b 0x40489e7 0x406f72c 0x42badfc 0x42badfd 0x4252b94 0x42549d5 0x4255913 0x4251bcc 0x40659e1
@@ -225,7 +242,9 @@ It's easy to locate.
 
 See this [example](example/slowlyleak/slowlyleak.go)
 
-The producer forget to close the task channel after produce finishes, so every request to this URI will leak a goroutine, we could curl http://localhost:10003/leak several time and got the following log:
+The producer forget to close the task channel after produce finishes, so every request 
+to this URI will leak a goroutine, we could curl http://localhost:10003/leak several 
+time and got the following log:
 
 ```
 goroutine profile: total 10
@@ -256,7 +275,8 @@ heap profile: 83: 374069984 [3300: 14768402720] @ heap/1048576
 
 See this [example](example/cpu_explode/cpu_explode.go).
 
-After warming up finished, curl http://localhost:10003/cpuex several times, then you'll see the cpu profile dump to your dump path.
+After warming up finished, curl http://localhost:10003/cpuex several times, then you'll
+see the cpu profile dump to your dump path.
 
 Notice the cpu profile currently doesn't support text mode.
 
@@ -313,7 +333,8 @@ See this [example](./example/thread_trigger/thread_trigger.go)
 
 This is a cgo block example, massive cgo blocking will cause many threads created.
 
-After warming up, curl http://localhost:10003/leak, then the thread profile and goroutine profile will be dump to dumpPath:
+After warming up, curl http://localhost:10003/leak, then the thread profile and goroutine 
+profile will be dumped to dumpPath:
 
 ```
 [2020-11-10 19:49:52.145][Holmes] pprof thread, config_min : 10, config_diff : 25, config_abs : 100,  previous : [8 8 8 8 8 8 8 8 8 1013], current : 1013

--- a/util.go
+++ b/util.go
@@ -182,3 +182,11 @@ func getBinaryFileName(filePath string, dumpType configureType) string {
 
 	return path.Join(filePath, type2name[dumpType]+"."+binarySuffix)
 }
+
+func ReachDangerousLimit(cur, d int) bool {
+	// not set dangerous limit
+	if d == 0 {
+		return false
+	}
+	return cur > d
+}


### PR DESCRIPTION
Main change: break long sentences to make them easier to read in IDE or Editor without dragging the screen from side to side.
Others: fix some typos.
