### PR TITLE
fix: 去除dump文件名中无意义的点.

### DIFF
--- a/util.go
+++ b/util.go
@@ -193,6 +193,9 @@ func matchRule(history ring, curVal, ruleMin, ruleAbs, ruleDiff, ruleMax int) (b
 
 func getBinaryFileName(filePath string, dumpType configureType, eventID string) string {
 	suffix := time.Now().Format("20060102150405.000") + ".log"
+	if len(eventID) == 0 {
+		return path.Join(filePath, check2name[dumpType]+"."+suffix)
+	}
 
 	return path.Join(filePath, check2name[dumpType]+"."+eventID+"."+suffix)
 }


### PR DESCRIPTION
#99  我发现这个eventID全局传递的不太好去除 所以直接在底层抹掉不需要eventID的文件名