### PR TITLE
fix: example reappearance

### DIFF
--- a/example/alloc/alloc.go
+++ b/example/alloc/alloc.go
@@ -19,9 +19,10 @@ package main
 
 import (
 	"fmt"
-	mlog "mosn.io/pkg/log"
 	"net/http"
 	"time"
+
+	mlog "mosn.io/pkg/log"
 
 	"mosn.io/holmes"
 )
@@ -45,7 +46,7 @@ func main() {
 }
 
 func alloc(wr http.ResponseWriter, req *http.Request) {
-	var m = make(map[string]string, 102400)
+	var m = make(map[string]string, 1073741824)
 	for i := 0; i < 1000; i++ {
 		m[fmt.Sprint(i)] = fmt.Sprint(i)
 	}

--- a/example/cpu_explode/cpu_explode.go
+++ b/example/cpu_explode/cpu_explode.go
@@ -18,13 +18,15 @@
 package main
 
 import (
-	mlog "mosn.io/pkg/log"
 	"net/http"
 	"time"
+
+	mlog "mosn.io/pkg/log"
 
 	"mosn.io/holmes"
 )
 
+// run `curl http://localhost:10003/cpuex` after 15s(warn up)
 func init() {
 	http.HandleFunc("/cpuex", cpuex)
 	go http.ListenAndServe(":10003", nil) //nolint:errcheck
@@ -44,7 +46,7 @@ func main() {
 func cpuex(wr http.ResponseWriter, req *http.Request) {
 	go func() {
 		for {
-			time.Sleep(time.Millisecond)
+
 		}
 	}()
 }


### PR DESCRIPTION
1. alloc: The allocation is too small to trigger.
2. cpuex: sleep suspension cannot be reproduced.