### PR TITLE
perf: get cgroup cpu core

### DIFF
--- a/util.go
+++ b/util.go
@@ -118,6 +118,7 @@ func getCGroupCPUCore() (float64, error) {
 		return 0, err
 	}
 
+	// No resource limit value is configured, the value is -1
 	if cpuQuota, err = readUint(cgroupCpuQuotaPath); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
1. optimize `getCGroupCPUCore()` to return the number of CPU cores when the value cannot be obtained.
2. optimize the use of `WithCGroup()` and `WithGoProcAsCPUCore()` together, and `WithCGroup()` has a higher priority.