### PR TITLE
兼容新版本接口(inuse_objects和inuse_space的上报处理)

### DIFF
--- a/reporters/pyroscope_reporter/client_config.go
+++ b/reporters/pyroscope_reporter/client_config.go
@@ -49,17 +49,56 @@ const (
 	ReservedTagKeyName = "__name__"
 )
 
+var (
+	heapSampleTypes = map[string]*SampleType{
+		"alloc_objects": {
+			Units:      "objects",
+			Cumulative: false,
+		},
+		"alloc_space": {
+			Units:      "bytes",
+			Cumulative: false,
+		},
+		"inuse_space": {
+			Units:       "bytes",
+			Aggregation: "average",
+			Cumulative:  false,
+		},
+		"inuse_objects": {
+			Units:       "objects",
+			Aggregation: "average",
+			Cumulative:  false,
+		},
+	}
+	goroutineSampleTypes = map[string]*SampleType{
+		"goroutine": {
+			DisplayName: "goroutines",
+			Units:       "goroutines",
+			Aggregation: "average",
+		},
+	}
+)
+
+type SampleType struct {
+	Units       string `json:"units,omitempty"`
+	Aggregation string `json:"aggregation,omitempty"`
+	DisplayName string `json:"display-name,omitempty"`
+	Sampled     bool   `json:"sampled,omitempty"`
+	Cumulative  bool   `json:"cumulative,omitempty"`
+}
+
 type UploadJob struct {
-	Name            string
-	StartTime       time.Time
-	EndTime         time.Time
-	SpyName         string
-	SampleRate      uint32
-	Units           string
-	AggregationType string
-	Format          UploadFormat
-	Profile         []byte
-	PrevProfile     []byte
+	Name             string
+	StartTime        time.Time
+	EndTime          time.Time
+	SpyName          string
+	SampleRate       uint32
+	Units            string
+	AggregationType  string
+	Format           UploadFormat
+	Profile          []byte
+	PrevProfile      []byte
+	SampleTypeConfig map[string]*SampleType
 }
 
 type RemoteConfig struct {

--- a/reporters/pyroscope_reporter/pyroscope_client_test.go
+++ b/reporters/pyroscope_reporter/pyroscope_client_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
 	"mosn.io/holmes"
 )
 
@@ -16,11 +17,9 @@ func TestMain(m *testing.M) {
 	log.Println("holmes initialing")
 	h, _ = holmes.New(
 		holmes.WithCollectInterval("1s"),
-		holmes.WithDumpPath("./"),
-		holmes.WithTextDump(),
 	)
 	log.Println("holmes initial success")
-	h.EnableCPUDump().Start()
+	h.EnableMemDump().EnableGoroutineDump().EnableCPUDump().Start()
 	time.Sleep(11 * time.Second)
 	log.Println("on running")
 	newMockServer()
@@ -47,9 +46,10 @@ func TestPyroscopeClient(t *testing.T) {
 
 	err = h.Set(
 		holmes.WithProfileReporter(pReporter),
-		holmes.WithGoroutineDump(5, 10, 20, 90, time.Second),
+		holmes.WithGoroutineDump(0, 0, 1, 2, time.Second),
 		holmes.WithCPUDump(0, 2, 80, time.Second),
-		holmes.WithCollectInterval("5s"),
+		holmes.WithMemDump(0, 1, 1, time.Second),
+		holmes.WithCollectInterval("1s"),
 	)
 	if err != nil {
 		log.Fatalf("fail to set opts on running time.")


### PR DESCRIPTION
使用pyroscope v0.37.2测试发现，heap信息上报之后，在pyroscope找不到inuse_space和inuse_objects，发现pyroscope api有所更新，所以兼容处理一下